### PR TITLE
Set func-visibility ignoreConstructors to true 

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     "avoid-throw": "error",
     "avoid-tx-origin": "error",
     "check-send-result": "error",
-    "func-visibility": ["error", { ignoreConstructors: false }],
+    "func-visibility": ["error", { ignoreConstructors: true }],
     "multiple-sends": "error",
     "no-complex-fallback": "error",
     "no-inline-assembly": "error",


### PR DESCRIPTION
According to the solhint documentation:

> A JSON object with a single property “ignoreConstructors” specifying if the rule should ignore constructors. (Note: This is required to be true for Solidity >=0.7.0 and false for <0.7.0)

We assume to use Solidity version above 7, so we're aligning the config here.

https://protofire.github.io/solhint/docs/rules/security/func-visibility.html

This PR ports changes from https://github.com/thesis/solhint-config/pull/2 to the master branch.